### PR TITLE
Filter events that rooms have declined

### DIFF
--- a/api.go
+++ b/api.go
@@ -138,16 +138,18 @@ func loadEvents() {
 
 func loadEventsForRoom(calendarName string, calendarId string) {
 	log.Printf("Loading %v", calendarName)
+	startTime := time.Now()
+	endTime := startTime.Truncate(24 * time.Hour).Add(24 * time.Hour)
 	events, err := client.Api().Events.List(calendarId).
-		TimeMin(time.Now().Format(time.RFC3339)).
-		TimeMax(time.Now().Truncate(24 * time.Hour).Add(24 * time.Hour).Format(time.RFC3339)).
+		TimeMin(startTime.Format(time.RFC3339)).
+		TimeMax(endTime.Format(time.RFC3339)).
 		SingleEvents(true).
 		OrderBy("startTime").Do()
 
 	if err != nil {
 		log.Printf("Error loading room %v: %v", calendarName, err)
 	} else {
-		rooms[calendarName] = CreateRoomFromEvents(calendarName, events.Items)
+		rooms[calendarName] = CreateRoomFromEvents(calendarId, calendarName, events.Items)
 		log.Printf("Finished loading %v events for %v", len(rooms[calendarName].Events), calendarName)
 	}
 }


### PR DESCRIPTION
People can try to book a room, but if it’s already booked, then the room
will decline the attempt to book it. It still records the event in the
room’s calendar though.

Currently, the API reports double-booked meetings, which causes
confusion when 2 groups attempt to enter a room.

This change checks that a room has accepted the event before reporting
it as booked.
