### PR TITLE
Make startTicker more resilient

### DIFF
--- a/api.go
+++ b/api.go
@@ -35,7 +35,6 @@ func main() {
 	calendars = parseCalendarConfig(calendarConfig)
 
 	startTicker()
-	go loadEvents()
 
 	log.Println("API is starting up on :" + port)
 	log.Println("Use Ctrl+C to stop")
@@ -129,6 +128,12 @@ func roomsLoaded() bool {
 func loadEvents() {
 	log.Print("Loading events...")
 
+	defer func() {
+		if err := recover(); err != nil {
+			log.Println("loadEvents failed:", err)
+		}
+	}()
+
 	client.Token = client.GetToken()
 
 	for calendarName, calendarId := range calendars {
@@ -173,6 +178,7 @@ func parseCalendarConfig(config string) map[string]string {
 }
 
 func startTicker() {
+	go loadEvents()
 	ticker := time.NewTicker(60 * time.Second)
 	quit := make(chan struct{})
 	go func() {

--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ func (c ApiClient) GetToken() *oauth2.Token {
 	token, err := conf.TokenSource(oauth2.NoContext).Token()
 
 	if err != nil {
-		log.Fatal("assertion error:", err)
+		panic(err)
 	}
 
 	log.Printf("New access token acquired.\n")


### PR DESCRIPTION
Being unable to retrieve an OAuth 2.0 token should not be fatal error
that causes the application to exit. There are plausible reasons why
this could happen:
- intermittent DNS / network issues
- server failure

So instead, we add a recovery pattern function, and panic where
appropriate, rather than logging a fatal issue.

Also changed `startTicker` to be self-contained, and run a goroutine
which tries to `loadEvents`. This is so that only `loadEvents` needs
to have a recovery pattern.
